### PR TITLE
[FIX] no barrier for single GPU training.

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -189,7 +189,7 @@ def main():
                 model, args.distributed, final_output_dir, f'model_{epoch}.pth'
             )
 
-        if args.local_rank != -1:
+        if args.distributed:
             torch.distributed.barrier()
 
         logging.info(


### PR DESCRIPTION
The script uses `torch.distributed.launch` for training. Although the default `local_rank` is -1 for a single GPU, torch distributed will set it to 0. Therefore the if condition here is not what we expect: when there is only 1 GPU, it shouldn't go to the barrier. Using `args.distributed` instead.