### PR TITLE
Change torch.distributed.launch to torchrun

### DIFF
--- a/lib/utils/utils.py
+++ b/lib/utils/utils.py
@@ -53,18 +53,18 @@ def create_logger(cfg, cfg_name, phase='train'):
     return str(final_output_dir)
 
 
-def init_distributed(args):
+def init_distributed(args,local_rank):
     args.num_gpus = int(os.environ["WORLD_SIZE"]) \
         if "WORLD_SIZE" in os.environ else 1
     args.distributed = args.num_gpus > 1
 
     if args.distributed:
         print("=> init process group start")
-        torch.cuda.set_device(args.local_rank)
+        torch.cuda.set_device(local_rank)
         torch.distributed.init_process_group(
             backend="nccl", init_method="env://",
             timeout=timedelta(minutes=180))
-        comm.local_rank = args.local_rank
+        comm.local_rank = local_rank
         print("=> init process group end")
 
 

--- a/run-alt.sh
+++ b/run-alt.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 train() {
-    python3 -m torch.distributed.launch \
-        --nnodes ${NODE_COUNT} \
+    #python3 -m torch.distributed.launch \
+    torchrun --nnodes ${NODE_COUNT} \
         --node_rank ${RANK} \
         --master_addr ${MASTER_ADDR} \
         --master_port ${MASTER_PORT} \
@@ -12,8 +12,8 @@ train() {
 
 
 test() {
-    python3 -m torch.distributed.launch \
-        --nnodes ${NODE_COUNT} \
+    #python3 -m torch.distributed.launch \
+    torchrun --nnodes ${NODE_COUNT} \
         --node_rank ${RANK} \
         --master_addr ${MASTER_ADDR} \
         --master_port ${MASTER_PORT} \

--- a/run-alt.sh
+++ b/run-alt.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 train() {
-    #python3 -m torch.distributed.launch \
     torchrun --nnodes ${NODE_COUNT} \
         --node_rank ${RANK} \
         --master_addr ${MASTER_ADDR} \
@@ -12,7 +11,6 @@ train() {
 
 
 test() {
-    #python3 -m torch.distributed.launch \
     torchrun --nnodes ${NODE_COUNT} \
         --node_rank ${RANK} \
         --master_addr ${MASTER_ADDR} \

--- a/tools/test.py
+++ b/tools/test.py
@@ -41,7 +41,6 @@ def parse_args():
                         type=str)
 
     # distributed training
-    #parser.add_argument("--local_rank", type=int, default=0)
     parser.add_argument("--port", type=int, default=9000)
 
     parser.add_argument('opts',

--- a/tools/test.py
+++ b/tools/test.py
@@ -41,7 +41,7 @@ def parse_args():
                         type=str)
 
     # distributed training
-    parser.add_argument("--local_rank", type=int, default=0)
+    #parser.add_argument("--local_rank", type=int, default=0)
     parser.add_argument("--port", type=int, default=9000)
 
     parser.add_argument('opts',
@@ -57,7 +57,8 @@ def parse_args():
 def main():
     args = parse_args()
 
-    init_distributed(args)
+    local_rank = int(os.environ["LOCAL_RANK"])
+    init_distributed(args,local_rank)
     setup_cudnn(config)
 
     update_config(config, args)
@@ -99,7 +100,7 @@ def main():
 
     if args.distributed:
         model = torch.nn.parallel.DistributedDataParallel(
-            model, device_ids=[args.local_rank], output_device=args.local_rank
+            model, device_ids=[local_rank], output_device=local_rank
         )
 
     # define loss function (criterion) and optimizer

--- a/tools/train.py
+++ b/tools/train.py
@@ -44,7 +44,7 @@ def parse_args():
                         type=str)
 
     # distributed training
-    parser.add_argument("--local_rank", type=int, default=-1)
+    #parser.add_argument("--local_rank", type=int, default=-1)
     parser.add_argument("--port", type=int, default=9000)
 
     parser.add_argument('opts',
@@ -60,7 +60,8 @@ def parse_args():
 def main():
     args = parse_args()
 
-    init_distributed(args)
+    local_rank = int(os.environ["LOCAL_RANK"])
+    init_distributed(args,local_rank)
     setup_cudnn(config)
 
     update_config(config, args)
@@ -108,8 +109,8 @@ def main():
 
     if args.distributed:
         model = torch.nn.parallel.DistributedDataParallel(
-            model, device_ids=[args.local_rank],
-            output_device=args.local_rank,
+            model, device_ids=[local_rank],
+            output_device=local_rank,
             find_unused_parameters=True
         )
 

--- a/tools/train.py
+++ b/tools/train.py
@@ -44,7 +44,6 @@ def parse_args():
                         type=str)
 
     # distributed training
-    #parser.add_argument("--local_rank", type=int, default=-1)
     parser.add_argument("--port", type=int, default=9000)
 
     parser.add_argument('opts',


### PR DESCRIPTION
CvT is running into errors because of torch.distributed.launch deprecation with latest PyTorch. It is recommended to use torchrun instead of torch.distributed.launch to avoid those. But torchrun requires reading local_rank from environment variable instead of command line argument as explained here: https://pytorch.org/docs/stable/elastic/run.html
This PR has changes to do the same for CvT.